### PR TITLE
Remove Cell Count from PID Motor Output Limits

### DIFF
--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -423,27 +423,18 @@
                             </table>
                             <table class="pid_titlebar pid_titlebar_extended motorOutputLimit">
                                 <tr>
-                                    <th class="third"></th>
                                     <th class="third" style="width: 33%;">
                                         <div>
                                             <div i18n="pidTuningMotorLimit" class="float-left"></div>
                                             <div class="helpicon cf_tip" i18n_title="pidTuningMotorLimitHelp"></div>
                                         </div>
                                     </th>
-                                    <th class="third" style="width: 33%;">
-                                        <div>
-                                            <div i18n="pidTuningCellCount" class="float-left"></div>
-                                            <div class="helpicon cf_tip" i18n_title="pidTuningCellCountHelp"></div>
-                                        </div>
-                                    </th>
                                 </tr>
                             </table>
                             <table class="motorOutputLimit">
                                 <tr>
-                                    <td class="third"></td>
                                     <td class="third"><input type="number" name="motorLimit" step="1" min="1"
                                             max="100" /></td>
-                                    <td class="third"><input type="number" name="cellCount" step="1" min="-1" max="8" />
                                     </td>
                                 </tr>
                             </table>


### PR DESCRIPTION
As per TODO. Let me know if I should remove the entire motor output limits box? 

From the description of this feature it seems to limit the throttle channel to allow you to use higher cell counts on setups tht can't handle them. For example 4S can be used on a drone setup for max 3S with a limited throttle.  